### PR TITLE
Handle issuer data uri

### DIFF
--- a/badgecheck/tasks/input.py
+++ b/badgecheck/tasks/input.py
@@ -62,7 +62,7 @@ def detect_input_type(state, task_meta=None, **options):
         new_actions.append(set_input_type(detected_type))
         if detected_type == 'url':
             new_actions.append(add_task(FETCH_HTTP_NODE, url=id_url))
-            new_actions.append(set_validation_subject(input_value))
+            new_actions.append(set_validation_subject(id_url))
     elif input_is_jws(input_value):
         detected_type = 'jws'
         new_actions.append(set_input_type(detected_type))

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -279,11 +279,11 @@ def validate_property(state, task_meta, **options):
                         add_task(VALIDATE_EXPECTED_NODE_CLASS, node_path=value_to_test_path,
                                  expected_class=task_meta.get('expected_class')))
                     continue
-                elif task_meta.get('allow_data_uri', False) and not PrimitiveValueValidator(ValueTypes.DATA_URI_OR_URL)(val):
+                elif task_meta.get('allow_data_uri') and not PrimitiveValueValidator(ValueTypes.DATA_URI_OR_URL)(val):
                     raise ValidationError("ID-type property {} had value `{}` that isn't URI or DATA URI in {}.".format(
                         prop_name, abv(val), abv_node(node_id, node_path))
                     )
-                elif not PrimitiveValueValidator(ValueTypes.IRI)(val):
+                elif not task_meta.get('allow_data_uri', False) and not PrimitiveValueValidator(ValueTypes.IRI)(val):
                     raise ValidationError(
                         "ID-type property {} had value `{}` not embedded node or in IRI format in {}.".format(
                             prop_name, abv(val), abv_node(node_id, node_path))
@@ -293,6 +293,8 @@ def validate_property(state, task_meta, **options):
                 except IndexError:
                     if not task_meta.get('fetch', False):
                         if task_meta.get('allow_remote_url') and PrimitiveValueValidator(ValueTypes.URL)(val):
+                            continue
+                        if task_meta.get('allow_data_uri') and PrimitiveValueValidator(ValueTypes.DATA_URI)(val):
                             continue
                         raise ValidationError(
                             'Node {} has {} property value `{}` that appears not to be in URI format'.format(

--- a/tests/test_verification_report.py
+++ b/tests/test_verification_report.py
@@ -1,3 +1,5 @@
+import os
+from openbadges_bakery import bake
 import responses
 import unittest
 from pydux import create_store
@@ -50,6 +52,15 @@ class VerificationReportTests(unittest.TestCase):
         store = verification_store(url)
         report = generate_report(store)
         self.assertEqual(report['report']['validationSubject'], url)
+
+    @responses.activate
+    def test_subject_set_from_badge_image(self):
+        with open(os.path.join(os.path.dirname(__file__), 'testfiles', 'public_domain_heart.png'), 'r') as f:
+            image = bake(f, test_components['2_0_basic_assertion'])
+            self.set_response_mocks()
+            store = verification_store(image)
+            report = generate_report(store)
+            self.assertEqual(report['report']['validationSubject'], 'https://example.org/beths-robotics-badge.json')
 
     @responses.activate
     def test_confirmed_recipient_profile_reported(self):

--- a/tests/test_verification_report.py
+++ b/tests/test_verification_report.py
@@ -59,7 +59,7 @@ class VerificationReportTests(unittest.TestCase):
 
     @responses.activate
     def test_subject_set_from_badge_image(self):
-        with open(os.path.join(os.path.dirname(__file__), 'testfiles', 'public_domain_heart.png'), 'r') as f:
+        with open(os.path.join(os.path.dirname(__file__), 'testfiles', 'public_domain_heart.png'), 'rb') as f:
             image = bake(f, test_components['2_0_basic_assertion'])
             self.set_response_mocks()
             store = verification_store(image)


### PR DESCRIPTION
If the issuer's "image" property was a data uri, the property was marked invalid. This resolves that erroneous error. 

Also, correctly sets `validationSubject`  when the input was an image with JSON data baked in.