### PR TITLE
Feature/validate compact iri

### DIFF
--- a/badgecheck/tasks/graph.py
+++ b/badgecheck/tasks/graph.py
@@ -202,7 +202,7 @@ def flatten_refetch_embedded_resource(state, task_meta, **options):
                         embedded_node_id, abv_node(node_path=[node_id, prop_name])
                     )))
             actions.append(add_node(embedded_node_id, data=value))
-            actions.append(actions.append(patch_node(node_id, {prop_name: embedded_node_id})))
+            actions.append(patch_node(node_id, {prop_name: embedded_node_id}))
 
     else:
         actions.append(patch_node(node_id, {prop_name: embedded_node_id}))

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -65,6 +65,7 @@ class OBClasses(object):
 
 class ValueTypes(object):
     BOOLEAN = 'BOOLEAN'
+    COMPACT_IRI = 'COMPACT_IRI'
     DATA_URI = 'DATA_URI'
     DATA_URI_OR_URL = 'DATA_URI_OR_URL'
     DATETIME = 'DATETIME'
@@ -98,6 +99,7 @@ class PrimitiveValueValidator(object):
             ValueTypes.EMAIL: self._validate_email,
             ValueTypes.IDENTITY_HASH: self._validate_identity_hash,
             ValueTypes.IRI: self._validate_iri,
+            ValueTypes.COMPACT_IRI: self._validate_compact_iri,
             ValueTypes.MARKDOWN_TEXT: self._validate_markdown_text,
             ValueTypes.RDF_TYPE: self._validate_rdf_type,
             ValueTypes.TELEPHONE: self._validate_tel,
@@ -113,6 +115,19 @@ class PrimitiveValueValidator(object):
     @staticmethod
     def _validate_boolean(value):
         return isinstance(value, bool)
+
+    @classmethod
+    def _validate_compact_iri(cls, value):
+        if value == 'id' or cls._validate_iri(value):
+            return True
+        try:
+            test_data = {'@context': OPENBADGES_CONTEXT_V2_DICT, value: 'TEST'}
+            expanded = jsonld.expand(test_data)
+            if len(list(expanded[0])) == 1:
+                return True
+        except (jsonld.JsonLdError, IndexError):
+            pass
+        return False
 
     @staticmethod
     def _validate_data_uri(value):
@@ -511,7 +526,7 @@ class ClassValidators(OBClasses):
             self.validators = (
                 {'prop_name': 'type', 'prop_type': ValueTypes.RDF_TYPE, 'required': False, 'many': True,
                     'default': 'VerificationObject'},
-                {'prop_name': 'verificationProperty', 'prop_type': ValueTypes.IRI, 'required': False},
+                {'prop_name': 'verificationProperty', 'prop_type': ValueTypes.COMPACT_IRI, 'required': False},
                 {'prop_name': 'startsWith', 'prop_type': ValueTypes.URL, 'required': False},
                 {'prop_name': 'allowedOrigins', 'prop_type': ValueTypes.TEXT, 'required': False,
                  'many': True}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -78,7 +78,7 @@ class PropertyValidationTests(unittest.TestCase):
         good_urls = ('http://www.example.com:8080/', 'http://www.example.com:8080/foo/bar',
                      'http://www.example.com/foo%20bar', 'http://www.example.com/foo/bar?a=b&c=d',
                      'http://www.example.com/foO/BaR', 'HTTPS://www.EXAMPLE.cOm/',
-                     'http://142.42.1.1:8080/', 'http://142.42.1.1/',
+                     'http://142.42.1.1:8080/', 'http://142.42.1.1/', 'http://localhost:3000/123',
                      'http://foo.com/blah_(wikipedia)#cite-1', 'http://a.b-c.de',
                      'http://userid:password@example.com/', "http://-.~:%40:80%2f:password@example.com",
                      'http://code.google.com/events/#&product=browser')
@@ -110,6 +110,36 @@ class PropertyValidationTests(unittest.TestCase):
             self.assertTrue(validator(url), "`{}` should pass IRI validation but failed.".format(url))
         for url in bad_iris:
             self.assertFalse(validator(url), "`{}` should fail IRI validation but passed.".format(url))
+
+
+class IriPropertyValidationTests(unittest.TestCase):
+    def test_validate_compacted_iri_value(self):
+        first_node = {
+            'type': 'Issuer',
+            'id': 'https://example.org/issuer1',
+            'verification': {
+                'verificationProperty': 'id'
+            }
+        }
+        state = {'graph': [first_node]}
+
+        validator = PrimitiveValueValidator(ValueTypes.COMPACT_IRI)
+        self.assertTrue(validator('id'))
+        self.assertTrue(validator('email'))
+        self.assertTrue(validator('telephone'))
+        self.assertTrue(validator('url'))
+        self.assertFalse(validator('sloths'))
+
+        task = add_task(
+            VALIDATE_PROPERTY,
+            node_path=[first_node['id'], 'verification'],
+            prop_name='verificationProperty',
+            prop_type=ValueTypes.COMPACT_IRI,
+            required=False
+        )
+
+        result, message, actions = validate_property(state, task)
+        self.assertTrue(result)
 
 
 class PropertyValidationTaskTests(unittest.TestCase):


### PR DESCRIPTION
Issuer Profiles that used the "verificationProperty" setting were not properly passing property-level validation checks for the "IRI" type when using a compact IRI like "email". A new type has been introduced to cover this case.