### PR TITLE
Handles objects that declare an "id" different from fetch URL

### DIFF
--- a/badgecheck/actions/action_types.py
+++ b/badgecheck/actions/action_types.py
@@ -14,6 +14,7 @@ Manage the state of the known entities related to the validation subject.
 ADD_NODE = 'ADD_NODE'
 PATCH_NODE = 'PATCH_NODE'
 UPDATE_NODE = 'UPDATE_NODE'
+PATCH_NODE_REFERENCE = 'PATCH_NODE_REFERENCE'
 
 """
 TASK Actions:

--- a/badgecheck/actions/graph.py
+++ b/badgecheck/actions/graph.py
@@ -1,4 +1,4 @@
-from .action_types import ADD_NODE, PATCH_NODE, UPDATE_NODE
+from .action_types import ADD_NODE, PATCH_NODE, PATCH_NODE_REFERENCE, UPDATE_NODE
 import sys
 
 
@@ -26,3 +26,18 @@ def patch_node(node_id, data):
     action = update_node(node_id, data)
     action['type'] = PATCH_NODE
     return action
+
+
+def patch_node_reference(node_path, new_id):
+    """
+    When a reference to another node in the graph needs to be updated
+    after discovering that it has a different canonical id, use this.
+    :param node_path: list
+    :param new_id: str
+    :return: dict
+    """
+    return {
+        'type': PATCH_NODE_REFERENCE,
+        'node_path': node_path,
+        'new_id': new_id
+    }

--- a/badgecheck/actions/tasks.py
+++ b/badgecheck/actions/tasks.py
@@ -57,11 +57,12 @@ def update_task(task_id, task_name, **kwargs):
     return task
 
 
-def report_message(msg, message_level=MESSAGE_LEVEL_INFO):
+def report_message(msg, message_level=MESSAGE_LEVEL_INFO, success=True):
     if message_level not in MESSAGE_LEVELS:
         raise TypeError("message")
     return {
         'type': REPORT_MESSAGE,
         'message': msg,
-        'messageLevel': message_level
+        'messageLevel': message_level,
+        'success': success
     }

--- a/badgecheck/reducers/graph.py
+++ b/badgecheck/reducers/graph.py
@@ -1,6 +1,6 @@
 import copy
 
-from ..actions.action_types import ADD_NODE, PATCH_NODE, UPDATE_NODE
+from ..actions.action_types import ADD_NODE, PATCH_NODE, PATCH_NODE_REFERENCE, UPDATE_NODE
 from ..state import get_node_by_id
 from ..utils import list_of
 
@@ -56,6 +56,20 @@ def graph_reducer(state=None, action=None):
             existing_node = get_node_by_id({'graph': state}, action.get('node_id'))
             updated_node = copy.copy(existing_node)
             updated_node.update(action.get('data'))
+            state = [node for node in state if node is not existing_node]
+            state.append(updated_node)
+        except IndexError:
+            pass
+    elif action.get('type') == PATCH_NODE_REFERENCE:
+        node_path = action['node_path']
+        new_node_id = action['new_id']
+        try:
+            existing_node = get_node_by_id({'graph': state}, node_path[0])
+            updated_node = copy.copy(existing_node)
+            if len(node_path) > 2:
+                raise NotImplementedError("TODO: handle complex node paths!")
+            prop = node_path[1]
+            updated_node[prop] = new_node_id
             state = [node for node in state if node is not existing_node]
             state.append(updated_node)
         except IndexError:

--- a/badgecheck/tasks/__init__.py
+++ b/badgecheck/tasks/__init__.py
@@ -47,3 +47,7 @@ FUNCTIONS = {
 
 def task_named(key):
     return FUNCTIONS[key]
+
+
+def run_task(state, task):
+    return task_named(task['name'])(state, task)

--- a/badgecheck/tasks/graph.py
+++ b/badgecheck/tasks/graph.py
@@ -6,7 +6,7 @@ import requests_cache
 import six
 import sys
 
-from ..actions.graph import add_node, patch_node
+from ..actions.graph import add_node, patch_node, patch_node_reference
 from ..actions.input import store_original_resource
 from ..actions.tasks import add_task, report_message
 from ..actions.validation_report import set_openbadges_version
@@ -14,10 +14,11 @@ from ..exceptions import TaskPrerequisitesError
 from ..openbadges_context import OPENBADGES_CONTEXT_V2_URI
 from ..reducers.graph import get_next_blank_node_id
 from ..state import get_node_by_id, node_match_exists
-from ..utils import list_of, jsonld_use_cache,make_string_from_bytes
+from ..utils import list_of, jsonld_use_cache,make_string_from_bytes, MESSAGE_LEVEL_WARNING
 
-from .task_types import (DETECT_AND_VALIDATE_NODE_CLASS, FETCH_HTTP_NODE, INTAKE_JSON, JSONLD_COMPACT_DATA,
-                         UPGRADE_1_0_NODE, UPGRADE_1_1_NODE, VALIDATE_EXPECTED_NODE_CLASS, VALIDATE_EXTENSION_NODE, )
+from .task_types import (DETECT_AND_VALIDATE_NODE_CLASS, FETCH_HTTP_NODE, INTAKE_JSON,
+                         JSONLD_COMPACT_DATA, UPGRADE_1_0_NODE, UPGRADE_1_1_NODE, VALIDATE_EXPECTED_NODE_CLASS,
+                         VALIDATE_EXTENSION_NODE, )
 from .utils import abbreviate_node_id as abv_node, filter_tasks, is_iri, is_url, task_result, URN_REGEX
 from .validation import OBClasses
 
@@ -47,7 +48,8 @@ def fetch_http_node(state, task_meta, **options):
     actions = [
         store_original_resource(node_id=url, data=result.text),
         add_task(INTAKE_JSON, data=result.text, node_id=url,
-                 expected_class=task_meta.get('expected_class'))]
+                 expected_class=task_meta.get('expected_class'),
+                 source_node_path=task_meta.get('source_node_path'))]
     return task_result(message="Successfully fetched JSON data from {}".format(url), actions=actions)
 
 
@@ -84,7 +86,7 @@ def intake_json(state, task_meta, **options):
     if openbadges_version in ['1.1', '2.0']:
         compact_action = add_task(
             JSONLD_COMPACT_DATA, node_id=node_id, openbadges_version=openbadges_version,
-            expected_class=expected_class, data=input_data
+            expected_class=expected_class, data=input_data, source_node_path=task_meta.get('source_node_path')
         )
         actions.append(compact_action)
 
@@ -97,7 +99,8 @@ def intake_json(state, task_meta, **options):
         ))
     elif openbadges_version == '1.0':
         actions.append(add_task(
-            UPGRADE_1_0_NODE, node_id=node_id, expected_class=expected_class, data=input_data
+            UPGRADE_1_0_NODE, node_id=node_id, expected_class=expected_class, data=input_data,
+            source_node_path=task_meta.get('source_node_path')
         ))
     else:
         return task_result(False, "Could not determine supported Open Badges object version for {}".format(node_id))
@@ -141,6 +144,7 @@ def jsonld_compact_data(state, task_meta, **options):
         if data and not sys.version[:3] < '3' and not isinstance(data, six.string_types):
             data = data.decode()
         input_data = json.loads(data)
+        expected_class = task_meta.get('expected_class')
     except TypeError:
         return task_result(False, "Could not load data")
 
@@ -154,14 +158,34 @@ def jsonld_compact_data(state, task_meta, **options):
 
     node_id = result.get('id', task_meta.get('node_id', get_next_blank_node_id()))
 
+    # Handle mismatch between URL node source and declared ID.
+    if result.get('id') and task_meta.get('node_id') and result['id'] != task_meta['node_id']:
+        refetch_action = add_task(FETCH_HTTP_NODE, url=result['id'])
+        if expected_class:
+            refetch_action['expected_class'] = expected_class
+        actions = [
+            report_message(
+                "Node fetched from source {} declared its id as {}".format(
+                    task_meta['node_id'], node_id), MESSAGE_LEVEL_WARNING, success=False
+            ),
+            refetch_action
+        ]
+        if task_meta.get('source_node_path'):
+            actions.append(patch_node_reference(task_meta['source_node_path'], node_id))
+        return task_result(
+            True,
+            "Successfully compacted node {} from source {} and found ID mismatch".format(node_id, task_meta['node_id']),
+            actions
+        )
+
     actions = [
         add_node(node_id, data=result)
     ] + _get_extension_actions(result, [node_id], new_contexts)
 
-    if task_meta.get('expected_class'):
+    if expected_class:
         actions.append(
             add_task(VALIDATE_EXPECTED_NODE_CLASS, node_id=node_id,
-                     expected_class=task_meta['expected_class'])
+                     expected_class=expected_class)
         )
     else:
         actions.append(add_task(DETECT_AND_VALIDATE_NODE_CLASS, node_id=node_id))

--- a/badgecheck/tasks/object_upgrades.py
+++ b/badgecheck/tasks/object_upgrades.py
@@ -133,7 +133,8 @@ def upgrade_1_0_node(state, task_meta, **options):
     data['@context'] = OPENBADGES_CONTEXT_V1_URI
 
     compact_action = add_task(
-        JSONLD_COMPACT_DATA, node_id=node_id, expected_class=expected_class, data=json.dumps(data))
+        JSONLD_COMPACT_DATA, node_id=node_id, expected_class=expected_class, data=json.dumps(data),
+        source_node_path=task_meta.get('source_node_path'))
     actions.append(compact_action)
     actions.append(add_task(
         UPGRADE_1_1_NODE, node_id=node_id, expected_class=expected_class,

--- a/badgecheck/tasks/utils.py
+++ b/badgecheck/tasks/utils.py
@@ -11,7 +11,7 @@ def task_result(success=True, message='', actions=None):
     :param success: bool
     :param message: str
     :param actions: list(dict)
-    :return:
+    :return: tuple
     """
     if not actions:
         actions = []

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -285,11 +285,12 @@ def validate_property(state, task_meta, **options):
         else:
             for i in range(len(values_to_test)):
                 val = values_to_test[i]
+                if isinstance(prop_value, (list, tuple,)):
+                    value_to_test_path = [node_id, prop_name, i]
+                else:
+                    value_to_test_path = [node_id, prop_name]
+
                 if isinstance(val, dict):
-                    if isinstance(prop_value, (list, tuple,)):
-                        value_to_test_path = [node_id, prop_name, i]
-                    else:
-                        value_to_test_path = [node_id, prop_name]
                     actions.append(
                         add_task(VALIDATE_EXPECTED_NODE_CLASS, node_path=value_to_test_path,
                                  expected_class=task_meta.get('expected_class')))
@@ -318,7 +319,9 @@ def validate_property(state, task_meta, **options):
                     else:
                         actions.append(
                             add_task(FETCH_HTTP_NODE, url=val,
-                                     expected_class=task_meta.get('expected_class')))
+                                     expected_class=task_meta.get('expected_class'),
+                                     source_node_path=value_to_test_path
+                                     ))
                 else:
                     actions.append(
                         add_task(VALIDATE_EXPECTED_NODE_CLASS, node_id=val,


### PR DESCRIPTION
Fixes #131:
* Refetches the object from the id declared in the object, throwing away the initial copy.
* Updates the reference in the graph to the object that was fetched
* Issues a warning to describe that this was done.