### PR TITLE
Add support for validating "version", "@language", and "related" props

### DIFF
--- a/tests/test_validate_related.py
+++ b/tests/test_validate_related.py
@@ -1,0 +1,49 @@
+import unittest
+
+from openbadges.verifier.actions.tasks import add_task
+from openbadges.verifier.tasks import run_task
+from openbadges.verifier.tasks.task_types import DETECT_AND_VALIDATE_NODE_CLASS
+
+
+class RelatedObjectTests(unittest.TestCase):
+    def test_validate_related_language(self):
+        assertion = {
+            'type': 'Assertion',
+            'id': 'http://example.com/assertion',
+            'verification': {
+                'type': 'HostedBadge'
+            },
+            'badge': 'http://example.com/badgeclass'
+        }
+        badgeclass = {
+            'id': 'http://example.com/badgeclass',
+            'type': 'BadgeClass',
+            '@language': 'es',
+            'issuer': 'http://example.com/issuer',
+            'related': {
+                'id': 'http://example.com/other_badgeclass',
+                '@language': 'en-US'
+            },
+            'name': 'Insignia Pronto'
+        }
+        state = {'graph': [assertion, badgeclass]}
+        task_meta = add_task(DETECT_AND_VALIDATE_NODE_CLASS, node_id=badgeclass['id'])
+        result, message, actions = run_task(state, task_meta)
+        self.assertTrue(result)
+
+        language_task = [t for t in actions if t.get('prop_name') == '@language'][0]
+        r, _, __ = run_task(state, language_task)
+        self.assertTrue(r, "The BadgeClass's language property is valid.")
+
+        related_task = [t for t in actions if t.get('prop_name') == 'related'][0]
+        result, message, actions = run_task(state, related_task)
+        self.assertTrue(result, "The related property is valid and queues up task discovery for embedded node")
+        result, message, actions = run_task(state, actions[0])
+        self.assertTrue(result, "Some tasks are discovered to validate the related node.")
+        self.assertEqual(len(actions), 2, "There are only tasks for 'id' and '@language'.")
+
+        for a in actions:
+            r, _, __ = run_task(state, a)
+            self.assertTrue(r, "Related node property validation is successful.")
+
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -891,7 +891,7 @@ class ClassValidationTaskTests(unittest.TestCase):
                 actions.extend(new_actions)
             self.assertTrue(result)
 
-        self.assertEqual(len(actions), 6)
+        self.assertEqual(len(actions), 8)
         self.assertTrue(CRITERIA_PROPERTY_DEPENDENCIES in [a.get('name') for a in actions])
 
     def test_run_criteria_task_discovery_and_validation_embedded(self):
@@ -919,7 +919,7 @@ class ClassValidationTaskTests(unittest.TestCase):
                 actions.extend(new_actions)
             self.assertTrue(result)
 
-        self.assertEqual(len(actions), 6)
+        self.assertEqual(len(actions), 8)
         self.assertTrue(CRITERIA_PROPERTY_DEPENDENCIES in [a.get('name') for a in actions])
 
     def test_many_criteria_disallowed(self):


### PR DESCRIPTION
Add support for validating "version", "@language", and "related" properties. For "related", a partial validation is done, only on embedded properties that are actually included, so that the related object may be minimal and only declare properties that distinguish the related version from the entity core to the test. Related objects are not fetched. Resolves #70.