### PR TITLE
Update Exception handling in call_task system

### DIFF
--- a/openbadges/verifier/verifier.py
+++ b/openbadges/verifier/verifier.py
@@ -65,8 +65,9 @@ def call_task(task_func, task_meta, store, options=DEFAULT_OPTIONS):
         message = "Task could not run due to unmet prerequisites."
         store.dispatch(resolve_task(task_meta.get('task_id'), success=False, result=message))
     except Exception as e:
+        error_message = traceback.format_exception_only(type(e), e)
         logger.error(traceback.format_exc())
-        message = "{} {}".format(e.__class__, e.message)
+        message = "{} {}".format(e.__class__, error_message)
         store.dispatch(resolve_task(task_meta.get('task_id'), success=False, result=message))
     else:
         store.dispatch(resolve_task(task_meta.get('task_id'), success=success, result=message))


### PR DESCRIPTION
Update the exception handling so that when tasks raise an exception this is less likely to result in the entire request failing (which previously could have happened if the exception doesn't implement the now-optional `message` attribute). Resolves #180.
