### PR TITLE
Add better validation of allowedOrigins

### DIFF
--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -129,7 +129,6 @@ class MessagesTests(unittest.TestCase):
         self.assertFalse(result['report']['valid'])
 
 
-
 class ResultReportTests(unittest.TestCase):
     def test_original_json_option(self):
         store = create_store(main_reducer, INITIAL_STATE)


### PR DESCRIPTION
Add better validation of allowedOrigins to require it to be actually a hostname, ip address or localhost, not a full URL with scheme and path and all that jazz. Resolves #179.