### PR TITLE
Fix setup.py to handle case where pypandoc throws OSError if not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
     pypandoc.convert_file('README.md', 'rst', outputfile='README.rst')
     with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
         README = readme.read()
-except (ImportError, RuntimeError):
+except (ImportError, RuntimeError, OSError):
     README = short_description
 
 # import VERSION


### PR DESCRIPTION
Fix setup.py to handle case where pypandoc throws OSError if not installed properly. Catch the correct error across multiple system environments.

This code was submitted by @coffindragger on behalf of Concentric Sky.