### PR TITLE
Validate individual extensions

### DIFF
--- a/openbadges/verifier/__init__.py
+++ b/openbadges/verifier/__init__.py
@@ -1,2 +1,1 @@
-from .verifier import verify
-from .verifier import validate_extensions
+from .verifier import validate_extensions, verify

--- a/openbadges/verifier/__init__.py
+++ b/openbadges/verifier/__init__.py
@@ -1,1 +1,2 @@
 from .verifier import verify
+from .verifier import validate_extensions

--- a/openbadges/verifier/tasks/graph.py
+++ b/openbadges/verifier/tasks/graph.py
@@ -202,7 +202,7 @@ def jsonld_compact_data(state, task_meta, **options):
             add_task(VALIDATE_EXPECTED_NODE_CLASS, node_id=node_id,
                      expected_class=expected_class)
         )
-    else:
+    elif task_meta.get('detectAndValidateClass', True):
         actions.append(add_task(DETECT_AND_VALIDATE_NODE_CLASS, node_id=node_id))
 
     return task_result(


### PR DESCRIPTION
Adds a python entry point to validate an individual extension implementation prior to inclusion in an independently verifiable badge object. Tox tests passing.

Code contributed by @coffindragger and myself on behalf of Concentric Sky.