### PR TITLE
Optional query parameter ‘url’ that will prefill the form

### DIFF
--- a/openbadges/verifier/server/app.py
+++ b/openbadges/verifier/server/app.py
@@ -16,7 +16,8 @@ def request_wants_json():
 
 @app.route("/")
 def home():
-    return render_template('index.html')
+    provided_url = request.args.get('url', "")
+    return render_template('index.html', url=provided_url)
 
 
 @app.route("/results", methods=['GET'])

--- a/openbadges/verifier/server/templates/index.html
+++ b/openbadges/verifier/server/templates/index.html
@@ -10,7 +10,7 @@
 <div class="form-group">
 	<label class="col-md-4 control-label" for="data">Badge Object Reference Data</label>
 	<div class="col-md-8">
-		<input id="data" name="data" type="text" placeholder="http://example.org/assertions/abc..." class="badgeforminput form-control input-md">
+		<input id="data" name="data" type="text" placeholder="http://example.org/assertions/abc..." class="badgeforminput form-control input-md" value="{{ url }}">
 		<span class="help-block badgeforminput">Paste the URL of a badge object or its JSON or signed JWS data directly</span>
 	</div>
 </div>


### PR DESCRIPTION
Adds the ability to link to the validator more usefully from badge sharing pages for hosted badges by opening up the validator with a url query parameter pointing to the hosted URL of the badge input field.

Work provided by @coffindragger on behalf of Concentric Sky.