### PR TITLE
Handle non-ascii characters in 0.5 assertion issuer name

### DIFF
--- a/openbadges/verifier/tasks/object_upgrades.py
+++ b/openbadges/verifier/tasks/object_upgrades.py
@@ -103,7 +103,7 @@ def upgrade_1_0_node(state, task_meta, **options):
             if verification_type == 'hosted':
                 node_id = data['verify'].get('url')
             elif verification_type == 'signed' and data.get('uid') is not None:
-                node_id = 'uid:{}'.format(data['uid'])
+                node_id = u'uid:{}'.format(data['uid'])
 
         if node_id:
             data['id'] = node_id

--- a/openbadges/verifier/tasks/object_upgrades.py
+++ b/openbadges/verifier/tasks/object_upgrades.py
@@ -167,7 +167,7 @@ def upgrade_0_5_node(state, task_meta, **options):
 
     if data.get('id') is None and node_id is None:
         return task_result(False, "Could not determine 'id' for data")
-    elif data.get('id') is None and  node_id is not None:
+    elif data.get('id') is None and node_id is not None:
         data['id'] = node_id
 
     if data.get('issued_on') is not None and data.get('issuedOn') is None:
@@ -200,7 +200,7 @@ def upgrade_0_5_node(state, task_meta, **options):
                     pass
 
         if issuer.get('name') and issuer.get('org'):
-            issuer['name'] = '{}: {}'.format(issuer['name'], issuer.pop('org'))
+            issuer['name'] = u'{}: {}'.format(issuer['name'], issuer.pop('org'))
 
         data['badge']['issuer'] = issuer
 

--- a/tests/test_legacy_versions.py
+++ b/tests/test_legacy_versions.py
@@ -320,6 +320,7 @@ class V1_0DetectionAndUpgradesTests(unittest.TestCase):
 class V1_0DetectionAndUpgradeTests(unittest.TestCase):
     def setUp(self):
         self.assertion_data = {
+            "uid": u"abc123™",
             "recipient": "sha256$a4a934a0bfc882a34a3e71650e40789453b2db9799a51a2d084a64caadd72397",
             "salt": "2e2bad0df9e11272ffbcee86e4c7edd4",
             "issued_on": "2017-01-01",
@@ -371,6 +372,7 @@ class V1_0DetectionAndUpgradeTests(unittest.TestCase):
         setUpContextCache()
         assertion_url = 'http://example.org/assertion'
         assertion_data = {
+            "uid": u"abc123™",
             "recipient": "sha256$a4a934a0bfc882a34a3e71650e40789453b2db9799a51a2d084a64caadd72397",
             "salt": "2e2bad0df9e11272ffbcee86e4c7edd4",
             "issued_on": "2017-01-01",
@@ -381,7 +383,7 @@ class V1_0DetectionAndUpgradeTests(unittest.TestCase):
                 "criteria": "http://example.org/criteria",
                 "issuer": {
                     "origin": "http://example.org",
-                    "name": "Test Issuer",
+                    "name": u"Test Issuer™",
                     "org": None,
                     "contact": 'test@example.com'
                 }

--- a/tests/test_legacy_versions.py
+++ b/tests/test_legacy_versions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import os
 import responses
@@ -329,7 +330,7 @@ class V1_0DetectionAndUpgradeTests(unittest.TestCase):
                 "criteria": "http://example.org/criteria",
                 "issuer": {
                     "origin": "example.org",
-                    "name": "Test Issuer",
+                    "name": u"Test Issuer™",
                     "org": None,
                     "contact": None
                 }


### PR DESCRIPTION
A user reported an inability to validate (due to a processing error) of an 0.5 assertion that had a non-ascii character in the issuer name property. This update handles this case as the 0.5 object is being upgraded to 1.0 syntax (on the way to being upgraded to 2.0 syntax).