### PR TITLE
Support uppercase variants of identityhash sha256/md5 hash outputs

### DIFF
--- a/openbadges/verifier/tasks/verification.py
+++ b/openbadges/verifier/tasks/verification.py
@@ -112,7 +112,7 @@ def verify_recipient_against_trusted_profile(state, task_meta, **options):
     if identity_node['hashed']:
         salt = identity_node.get('salt', '')
         for possible_id in p:
-            if _matches_hash(possible_id, a, salt):
+            if _matches_hash(possible_id, a.lower(), salt):
                 confirmed_id = possible_id
                 break
         else:


### PR DESCRIPTION
As reported in #216, an implementer had an uppercase expression of a sha256 hash in the IdentityHash of a recipient object. The spec is not absolutely explicit that the lowercase expression should be used, so we should also support this use case (which was valid under the previous non-2.0-supporting mozilla validator). This PR allows the uppercase expression or the lowercase expression of the IdentityHash data type.