### PR TITLE
Added User-Agent in utils.py to prevent server blocking

### DIFF
--- a/openbadges/verifier/utils.py
+++ b/openbadges/verifier/utils.py
@@ -47,7 +47,7 @@ class CachableDocumentLoader(object):
                     code='loading document failed')
 
             response = self.session.get(
-                url, headers={'Accept': 'application/ld+json, application/json'})
+                url, headers={'User-Agent': 'Open Badges Validator Core', 'Accept': 'application/ld+json, application/json'})
 
             doc = {'contextUrl': None, 'documentUrl': url, 'document': response.text}
 


### PR DESCRIPTION
Many websites are configured to block requests with a missing User-Agent
Added
'User-Agent': 'Open Badges Validator Core'
to the get headers on line 50