### PR TITLE
Added User-Agent in graph.py to prevent server blocking

### DIFF
--- a/openbadges/verifier/tasks/graph.py
+++ b/openbadges/verifier/tasks/graph.py
@@ -37,7 +37,7 @@ def fetch_http_node(state, task_meta, **options):
         session = requests.Session()
 
     result = session.get(
-        url, headers={'Accept': 'application/ld+json, application/json, image/png, image/svg+xml'}
+        url, headers={'User-Agent': 'Open Badges Validator Core', 'Accept': 'application/ld+json, application/json, image/png, image/svg+xml'}
     )
 
     try:


### PR DESCRIPTION
Many websites are configured to block requests with a missing User-Agent
For me this was causing an error for FETCH_HTTP_NODE on validating my assertion json url:
"Unknown Content-Type (Not image/png or image/svg+xml)"

It was solved after adding
'User-Agent': 'Open Badges Validator Core'
to the headers on line 40 of verifier/tasks/graph.py