### PR TITLE
use json() method of Response object 

### DIFF
--- a/openbadges/verifier/tasks/graph.py
+++ b/openbadges/verifier/tasks/graph.py
@@ -41,7 +41,8 @@ def fetch_http_node(state, task_meta, **options):
     )
 
     try:
-        json.loads(result.text)
+        json_body = result.json()
+        response_text_with_proper_encoding = json.dumps(json_body)
     except ValueError:
         content_type = result.headers.get('Content-Type', 'UNKNOWN')
 
@@ -65,8 +66,8 @@ def fetch_http_node(state, task_meta, **options):
             True, 'Successfully fetched image from {}'.format(url), actions)
 
     actions = [
-        store_original_resource(node_id=url, data=result.text),
-        add_task(INTAKE_JSON, data=result.text, node_id=url,
+        store_original_resource(node_id=url, data=response_text_with_proper_encoding),
+        add_task(INTAKE_JSON, data=response_text_with_proper_encoding, node_id=url,
                  expected_class=task_meta.get('expected_class'),
                  source_node_path=task_meta.get('source_node_path'))]
     return task_result(message="Successfully fetched JSON data from {}".format(url), actions=actions)


### PR DESCRIPTION
We discovered a couple cases where the requests library didn't properly handle certain characters in JSON in UTF-8 when response.text was used, but we found that when a UTF-8 charset was forced on a response object, the resulting data was correctly represented in python unicode strings. 

Turns out the responses library has a better handling of this with some better charset detection that is compatible with json built into its `Response.json()` method. Thanks @jcreed-csky for the contribution.

This PR updates the code to use json() method of Response object to resolve issues around content-type encoding: prevents encoding errors / throws same error as json.loads