### PR TITLE
Loosened the dependency version of Click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .cache/
 README.rst
 .vscode/launch.json
+.venv

--- a/openbadges/version.py
+++ b/openbadges/version.py
@@ -1,1 +1,1 @@
-VERSION = (1, 1, 2) 
+VERSION = (1, 1, 3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ future==0.16.0
 jsonschema==2.6.0
 language-tags==0.4.3
 openbadges_bakery==1.1.0
-pycryptodome==3.6.6
+pycryptodome>=3.6.6
 pydux==0.2.2
 PyLD==0.7.1
 python-jose==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pydux==0.2.2
 PyLD==0.7.1
 python-jose==3.0.1
 python-mimeparse==1.6.0
-pytz==2017.2
+pytz >= 2017.2
 requests >= 2.13
 requests_cache >= 0.4.13
 rfc3986==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     install_requires=[
         'aniso8601>=1.2.0',
-        'Click == 6.7',
+        'Click >= 6.7',
         'future==0.16.0',
         'jsonschema==2.6.0',
         'language-tags==0.4.3',

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'jsonschema==2.6.0',
         'language-tags==0.4.3',
         'openbadges-bakery>=1.1.0',
-        'pycryptodome==3.6.6',
+        'pycryptodome>=3.6.6',
         'pydux==0.2.2',
         'PyLD==0.7.1',
         'python-jose==3.0.1',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'PyLD==0.7.1',
         'python-jose==3.0.1',
         'python-mimeparse==1.6.0',
-        'pytz==2017.2',
+        'pytz >= 2017.2',
         'requests >= 2.13',
         'requests_cache==0.4.13',
         'rfc3986==0.4.1',


### PR DESCRIPTION
Pinning the version of Click makes it impossible to upgrade to other often used dependencies like Celery.